### PR TITLE
add adosearch

### DIFF
--- a/modules/adosearch.yml
+++ b/modules/adosearch.yml
@@ -1,0 +1,13 @@
+name: "adosearch"
+repo: Obapelumi/adosearch
+description: "typed, deeply nested database search for adonis.js applications"
+icon: ""
+github: https://github.com/Obapelumi/adosearch
+website: https://github.com/Obapelumi/adosearch
+npm: "adosearch"
+learn_more: ""
+category: Database
+type: 3rd-party
+maintainers:
+  - name: Emmanuel
+    github: Obapelumi


### PR DESCRIPTION
So excited to finally release [adosearch](https://github.com/Obapelumi/adosearch) 

Adosearch is an [Adonis.js Query Scope](https://docs.adonisjs.com/guides/models/query-scopes#document) that makes advanced search across multiple models trivial to implement.
Inspired by the [sofa/eloquence-base](https://github.com/jarektkaczyk/eloquence/wiki/Builder-searchable-and-more) laravel package.