### PR TITLE
Show lastupdated and supported version on Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Field Name      | Auto sync | Description
 `category`      | No        | Package category from [./lib/categories.json](./lib/categories.json)
 `type`          | No        | `community` (for [adonisjs-community](https://github.com/adonisjs-community/)), `official` (for https://github.com/) or `3rd-party`
 `maintainers`   | Yes       | List of maintainers each item has `name`, `github` and `avatar`
+`adonisversions` | No        | List of supported AdonisJS versions each item has `name`
 
 
 ## Maintenance

--- a/lib/modules.ts
+++ b/lib/modules.ts
@@ -139,6 +139,7 @@ export async function getModule (name): Promise<ModuleInfo> {
     learn_more: '',
     category: 'Devtools', // see modules/_categories.json
     type: '3rd-party', // official, community, 3rd-party
+    adonisversions: [],
     maintainers: [],
     contributors: []
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,10 @@ export interface MaintainerInfo {
   twitter?: string
 }
 
+export interface AdonisVersion {
+  name: string
+}
+
 export interface GithubContributor {
   login: string
   name?: string
@@ -25,6 +29,7 @@ export interface ModuleInfo {
   learn_more: string
   category: (typeof categories)[number]
   type: ModuleType
+  adonisversions: AdonisVersion[]
   maintainers: MaintainerInfo[]
   contributors: GithubContributor[]
 
@@ -32,6 +37,7 @@ export interface ModuleInfo {
   downloads?: number
   tags?: string[]
   stars?: number
+  updatedAt?: number
   publishedAt?: number
   createdAt?: number
 }

--- a/modules/adonis-cache.yml
+++ b/modules/adonis-cache.yml
@@ -11,3 +11,5 @@ type: 3rd-party
 maintainers:
   - name: Melchyore
     github: Melchyore
+adonisversions:
+  - name: 5.*

--- a/modules/bull-queue.yml
+++ b/modules/bull-queue.yml
@@ -11,3 +11,5 @@ type: 3rd-party
 maintainers:
   - name: Romain Lanz
     github: RomainLanz
+adonisversions:
+  - name: 5.*

--- a/modules/bull.yml
+++ b/modules/bull.yml
@@ -11,3 +11,5 @@ type: 3rd-party
 maintainers:
   - name: Rocketseat
     github: Rocketseat
+adonisversions:
+  - name: 5.*

--- a/modules/bullmq.yml
+++ b/modules/bullmq.yml
@@ -11,3 +11,5 @@ type: 3rd-party
 maintainers:
   - name: reg2005
     github: reg2005
+adonisversions:
+  - name: 5.*

--- a/modules/cache.yml
+++ b/modules/cache.yml
@@ -11,3 +11,5 @@ type: 3rd-party
 maintainers:
   - name: reg2005
     github: reg2005
+adonisversions:
+  - name: 5.*

--- a/modules/cloudinary.yml
+++ b/modules/cloudinary.yml
@@ -11,3 +11,5 @@ type: 3rd-party
 maintainers:
   - name: liam-edwards
     github: liam-edwards
+adonisversions:
+  - name: 5.*

--- a/modules/jwt-auth.yml
+++ b/modules/jwt-auth.yml
@@ -11,3 +11,5 @@ type: 3rd-party
 maintainers:
   - name: maxgalbu
     github: maxgalbu
+adonisversions:
+  - name: 5.*

--- a/modules/lucid-soft-deletes.yml
+++ b/modules/lucid-soft-deletes.yml
@@ -11,3 +11,5 @@ type: 3rd-party
 maintainers:
   - name: lookinlab
     github: lookinlab
+adonisversions:
+  - name: 5.*

--- a/modules/request-throttler.yml
+++ b/modules/request-throttler.yml
@@ -11,3 +11,5 @@ type: 3rd-party
 maintainers:
   - name: reg2005
     github: reg2005
+adonisversions:
+  - name: 5.*

--- a/modules/sentry.yml
+++ b/modules/sentry.yml
@@ -11,3 +11,5 @@ type: 3rd-party
 maintainers:
   - name: reg2005
     github: reg2005
+adonisversions:
+  - name: 5.*

--- a/modules/swagger.yml
+++ b/modules/swagger.yml
@@ -11,3 +11,5 @@ type: 3rd-party
 maintainers:
   - name: reg2005
     github: reg2005
+adonisversions:
+  - name: 5.*

--- a/website/components/CardModule.vue
+++ b/website/components/CardModule.vue
@@ -37,12 +37,44 @@
           class="flex text-lg font-semibold items-center dark:text-white h-9 line-2 leading-tight"
         >
           <span>{{ mod.name }}</span>
+          
           <UnoIcon
             v-if="mod.type === 'official'"
             v-tooltip="{ content: 'Official',classes: tooltipClass }"
             class="i-carbon-badge text-yellow-600 text-lg ml-1 my-auto opacity-85"
           />
+                    
+          <span
+            v-for="version in mod.adonisversions"
+            v-tooltip="{ content: 'Supported Adonis Version',classes: tooltipClass }"
+            :aria-label="version.name"
+            class="right+5 -top-1 bg-gray-100 text-gray-800 relative text-xs font-medium m-1 p-1 py-0.6 rounded dark:bg-gray-700 dark:text-gray-300"
+          >
+            {{ version.name }}
+          </span>
+
         </h2>
+        <div class="flex -space-x-3 hover:space-x-0 absolute hover:bg-white mt-2 dark:hover:bg-secondary-darkest">
+          <a
+            v-for="contributor of mod.contributors.slice(0, 5).reverse()"
+            :key="contributor.login"
+            v-tooltip="{ content: contributor.name || contributor.login, classes: ['bg-primary', 'text-white', 'px-2', 'py-1', 'rounded', 'text-sm', 'mb-2'] }"
+            :aria-label="contributor.name || contributor.login"
+            :href="`https://github.com/${contributor.login}`"
+            target="_blank"
+            rel="noopener"
+          >
+            <!-- TODO: use <nuxt-img> -->
+            <img
+              class="w-7 h-7 flex rounded-full text-white border-2 border-grey dark:border-primary-900"
+              :src="'https://api.nuxtjs.org/api/ipx/s_44,f_webp/gh_avatar/' + contributor.login"
+              :alt="contributor.name|| contributor.login"
+              format="jpg"
+              width="28"
+              height="28"
+            >
+          </a>
+        </div>    
       </div>
     </div>
 
@@ -60,6 +92,7 @@
           :href="mod.github"
           aria-label="stars"
           target=" _blank"
+          title="Github Stars"
           rel="noopener"
           class="flex whitespace-nowrap w-full mr-4 text-sky-dark hover:text-primary dark:hover:text-primary-300 dark:text-white"
         >
@@ -75,6 +108,7 @@
           :href="npmUrl(mod)"
           aria-label="npm"
           target=" _blank"
+          title="Downloads last 30 days"
           rel="noopener"
           class="flex whitespace-nowrap w-full mr-4 text-sky-dark hover:text-primary dark:hover:text-primary-300 dark:text-white"
         >
@@ -83,34 +117,29 @@
             class="text-sm leading-5 font-medium truncate"
           >{{ numberFormat(mod.downloads) }} installs</div>
         </a>
-      </div>
-      <div class="flex -space-x-3 hover:space-x-0 absolute right-0 -bottom-1 hover:bg-white  dark:hover:bg-secondary-darkest">
         <a
-          v-for="contributor of mod.contributors.slice(0, 5).reverse()"
-          :key="contributor.login"
-          v-tooltip="{ content: contributor.name || contributor.login, classes: ['bg-primary', 'text-white', 'px-2', 'py-1', 'rounded', 'text-sm', 'mb-2'] }"
-          :aria-label="contributor.name || contributor.login"
-          :href="`https://github.com/${contributor.login}`"
-          target="_blank"
+          v-if="mod.updatedAt"
+          :href="npmUrl(mod)"
+          aria-label="npm_date"
+          target=" _blank"
+          title="Last update"
           rel="noopener"
+          class="flex whitespace-nowrap w-full mr-4 text-sky-dark hover:text-primary dark:hover:text-primary-300 dark:text-white"
         >
-          <!-- TODO: use <nuxt-img> -->
-          <img
-            class="w-7 h-7 flex rounded-full text-white border-4 border-white dark:border-primary-900"
-            :src="'https://api.nuxtjs.org/api/ipx/s_44,f_webp/gh_avatar/' + contributor.login"
-            :alt="contributor.name|| contributor.login"
-            format="jpg"
-            width="28"
-            height="28"
-          >
+        <UnoIcon class="mr-2 i-carbon-calendar" />
+          <div
+            class="text-sm leading-5 font-medium truncate"
+          >{{ formatDate(mod.updatedAt) }}</div>
         </a>
-      </div>
+        
+      </div>      
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ModuleInfo, MaintainerInfo } from '~/../lib/types'
+// import moment from 'moment';
 import { numberFormatter } from '~/utils/format'
 import { CATEGORIES_ICONS } from '~/composables/constants'
 
@@ -118,6 +147,13 @@ defineProps<{ mod: ModuleInfo }>()
 
 const coverError = ref(false)
 const tooltipClass = 'bg-secondary-dark text-white px-2 py-1 m-1 rounded text-sm shadow'
+
+function formatDate (datestring: string){
+  if (datestring) {
+    const date = new Date(datestring);  
+    return new Intl.DateTimeFormat('default', {month: 'short', year: '2-digit'}).format(date);
+    }
+}
 
 function numberFormat (num: number, options = { precision: 1 }) {
   return numberFormatter(num, options)

--- a/website/components/TheMain.vue
+++ b/website/components/TheMain.vue
@@ -148,6 +148,7 @@ const fuseOptions = {
     'npm',
     'category',
     'maintainers.name',
+    'adonisversion.name',
     'maintainers.github',
     'description',
     'repo',

--- a/website/server/api/modules.ts
+++ b/website/server/api/modules.ts
@@ -37,12 +37,14 @@ async function fetchModuleStats (module: ModuleInfo) {
     module.stars = github.stars
     module.publishedAt = +new Date(npm.publishedAt || undefined)
     module.createdAt = +new Date(npm.createdAt || undefined)
+    module.updatedAt = +new Date(npm.updatedAt || undefined)
     module.contributors = contributors
   } else {
     module.downloads = rand(0, 500)
     module.stars = rand(0, 2000)
     module.publishedAt = rand(1_600_000_000_000, 1_630_000_000_000)
     module.createdAt = rand(1_600_000_000_000, 1_630_000_000_000)
+    module.updatedAt = rand(1_600_000_000_000, 1_630_000_000_000)
     module.contributors = [
       { login: 'poppinss' },
       { login: 'adonisjs' }


### PR DESCRIPTION
Hi, 

I extended the cards to show the latest update from npm and show manual badges.
The badges should help to identify supported anonisjs versions more easily.
All should help to find up-to-date packages more easily.

Only used existing data and badges are optional only. No deeper / too complex logic.

![image](https://user-images.githubusercontent.com/27913135/223989125-3cc9de8d-7885-4735-92d7-924d4f309ee7.png)
![image](https://user-images.githubusercontent.com/27913135/223989521-a1e6691c-513a-4faa-a4e5-3257929c712d.png)
