### PR TITLE
Add missing "Testing" to categories

### DIFF
--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -11,5 +11,6 @@ export const categories = [
   'Payment',
   'Rendering',
   'Security',
-  'Storage'
+  'Storage',
+  'Testing'
 ] as const


### PR DESCRIPTION
Testing is used as category for several packages, but it's not included in categories array
Making `yarn sync` throw error:

```
Error: Unknown category Testing for table-driven-html-reporter.
Supported categories: Authentication, Authorization, Communication, Database, Deployment, Devtools, Extensions, Messaging, Monitoring, Payment, Rendering, Security, Storage
    at sync (/home/mcsneaky/Projects/adonis-packages/lib/modules.ts:61:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 67)
    at async syncAll (/home/mcsneaky/Projects/adonis-packages/lib/modules.ts:169:26)
    at async main (/home/mcsneaky/Projects/adonis-packages/lib/cli.ts:17:27)
error Command failed with exit code 1.
```