### PR TITLE
update adonisjs-maintenance compatibility

### DIFF
--- a/content/packages/maintenance.yml
+++ b/content/packages/maintenance.yml
@@ -12,4 +12,4 @@ maintainers:
   - name: Michael V.
     github: MichaelBelgium
 compatibility:
-  adonis: ^5.9.0
+  adonis: ^5.9.0 || ^6.2.0


### PR DESCRIPTION
v6 support!

Not sure if it should be `^6.0.0` or `^6.2.0` though, picked the latter just to be sure, as i wasn't part of v6 alpha and such