### PR TITLE
fix: give a default baseUrl on markdown links

### DIFF
--- a/app/services/packages_fetcher.ts
+++ b/app/services/packages_fetcher.ts
@@ -178,7 +178,7 @@ export class PackagesFetcher {
 
     return {
       package: this.#mergePackageStatsAndInfo(pkg, stats),
-      readme: this.#markdownRenderer.render(readme),
+      readme: this.#markdownRenderer.render(readme, pkg.github),
     }
   }
 }


### PR DESCRIPTION
I noticed some link work on GitHub but don't work on Adonis package because they are relative URLs.

Example: "MIT License" link on the auditing package page: https://packages.adonisjs.com/packages/adonis-auditing