### PR TITLE
Update remix-adonisjs website URL

### DIFF
--- a/content/packages/remix-adonisjs.yml
+++ b/content/packages/remix-adonisjs.yml
@@ -12,4 +12,4 @@ maintainers:
 type: 3rd-party
 icon: remix.png
 github: https://github.com/jarle/remix-adonisjs
-website: https://remix-adonisjs.matstack.dev/
+website: https://matstack.dev/remix-adonisjs/


### PR DESCRIPTION
The URL has been changed from a subdomain to a subpath of matstack.dev