### PR TITLE
Add and update @foadonis packages

### DIFF
--- a/content/packages/foadonis-graphql.yml
+++ b/content/packages/foadonis-graphql.yml
@@ -1,0 +1,13 @@
+name: '@foadonis/graphql'
+category: Communication
+npm: '@foadonis/graphql'
+repo: FriendsOfAdonis/FriendsOfAdonis
+description: Create GraphQL APIs powered by Apollo with Adonis
+icon: foadonis.png
+compatibility:
+  adonis: ^6.0.0
+firstReleaseAt: '2025-01-12T15:18:50.355Z'
+lastReleaseAt: '2025-01-12T22:03:47.155Z'
+type: 3rd-party
+github: https://github.com/FriendsOfAdonis/FriendsOfAdonis/tree/main/packages/graphql
+website: https://friendsofadonis.com/docs/graphql

--- a/content/packages/foadonis-magnify.yml
+++ b/content/packages/foadonis-magnify.yml
@@ -1,7 +1,7 @@
-name: magnify
+name: '@foadonis/magnify'
 category: Database
 npm: '@foadonis/magnify'
-repo: FriendsOfAdonis/magnify
+repo: FriendsOfAdonis/FriendsOfAdonis
 description: Plug and play full-text search for your Adonis application.
 icon: foadonis.png
 compatibility:
@@ -9,5 +9,5 @@ compatibility:
 firstReleaseAt: '2024-09-28T15:18:50.355Z'
 lastReleaseAt: '2024-10-02T22:03:47.155Z'
 type: 3rd-party
-github: https://github.com/FriendsOfAdonis/magnify/tree/main
-website: https://friendsofadonis.github.io/docs/magnify/introduction
+github: https://github.com/FriendsOfAdonis/FriendsOfAdonis/tree/main/packages/magnify
+website: https://friendsofadonis.com/docs/magnify

--- a/content/packages/foadonis-maintenance.yml
+++ b/content/packages/foadonis-maintenance.yml
@@ -1,0 +1,13 @@
+name: '@foadonis/maintenance'
+category: Extensions
+npm: '@foadonis/maintenance'
+repo: FriendsOfAdonis/FriendsOfAdonis
+description: Safely set your Adonis application in maintenance mode.
+icon: foadonis.png
+compatibility:
+  adonis: ^6.0.0
+type: 3rd-party
+firstReleaseAt: '2025-01-12T15:18:50.355Z'
+lastReleaseAt: '2025-01-12T22:03:47.155Z'
+github: https://github.com/FriendsOfAdonis/FriendsOfAdonis/tree/main/packages/maintenance
+website: https://friendsofadonis.com/docs/maintenance

--- a/content/packages/foadonis-openapi.yml
+++ b/content/packages/foadonis-openapi.yml
@@ -1,0 +1,13 @@
+name: '@foadonis/openapi'
+category: DevTools
+npm: '@foadonis/openapi'
+repo: FriendsOfAdonis/FriendsOfAdonis
+description: Generate OpenAPI V3 compliant specifications using decorators
+icon: foadonis.png
+compatibility:
+  adonis: ^6.0.0
+type: 3rd-party
+firstReleaseAt: '2025-01-12T15:18:50.355Z'
+lastReleaseAt: '2025-01-12T22:03:47.155Z'
+github: https://github.com/FriendsOfAdonis/FriendsOfAdonis/tree/main/packages/openapi
+website: https://friendsofadonis.com/docs/openapi

--- a/content/packages/foadonis-shopkeeper.yml
+++ b/content/packages/foadonis-shopkeeper.yml
@@ -1,7 +1,7 @@
-name: shopkeeper
+name: '@foadonis/shopkeeper'
 category: Payment
 npm: '@foadonis/shopkeeper'
-repo: FriendsOfAdonis/shopkeeper
+repo: FriendsOfAdonis/FriendsOfAdonis
 description: Adonis Shopkeeper provides an expressive, fluent interface to Stripe's subscription billing services.
 icon: foadonis.png
 compatibility:
@@ -9,5 +9,5 @@ compatibility:
 firstReleaseAt: '2024-09-23T15:49:48.861Z'
 lastReleaseAt: '2024-09-26T23:05:50.123Z'
 type: 3rd-party
-github: https://github.com/FriendsOfAdonis/shopkeeper/tree/main
-website: https://friendsofadonis.github.io/docs/shopkeeper/introduction
+github: https://github.com/FriendsOfAdonis/FriendsOfAdonis/tree/main/packages/shopkeeper
+website: https://friendsofadonis.com/docs/shopkeeper


### PR DESCRIPTION
This pull request updates existing packages to point to the new documentation website and repository and add three packages `@foadonis/graphql` `@foadonis/openapi`, `@foadonis/maintenance`.