### PR TITLE
Add package @7nohe/adonis-typed-links

### DIFF
--- a/content/packages/adonis-bullet.yml
+++ b/content/packages/adonis-bullet.yml
@@ -1,0 +1,12 @@
+name: '@7nohe/adonis-bullet'
+category: DevTools
+npm: '@7nohe/adonis-bullet'
+repo: 7nohe/adonis-bullet
+description: AdonisJS helper to kill N+1 queries
+compatibility:
+  adonis: ^6.0.0
+firstReleaseAt: '2025-02-02T23:32:51.896Z'
+lastReleaseAt: '2025-02-09T07:44:08.695Z'
+type: 3rd-party
+github: https://github.com/7nohe/adonis-bullet/tree/main
+website: https://github.com/7nohe/adonis-bullet/tree/main

--- a/content/packages/adonis-typed-links.yml
+++ b/content/packages/adonis-typed-links.yml
@@ -1,0 +1,12 @@
+name: '@7nohe/adonis-typed-links'
+category: Communication
+npm: '@7nohe/adonis-typed-links'
+repo: 7nohe/adonis-typed-links
+description: Provides strongly-typed wrappers for Inertia.js's Links, Manual Visits, and Form Helper from AdonisJS routing
+compatibility:
+  adonis: ^6.0.0
+firstReleaseAt: '2024-10-06T13:12:56.319Z'
+lastReleaseAt: '2025-02-11T23:57:07.975Z'
+type: 3rd-party
+github: https://github.com/7nohe/adonis-typed-links/tree/main
+website: https://github.com/7nohe/adonis-typed-links/tree/main


### PR DESCRIPTION
Provides strongly-typed wrappers for Inertia.js's Links, Manual Visits, and Form Helper from AdonisJS routing