### PR TITLE
Added missing button link

### DIFF
--- a/inertia/pages/home/components/main_section.vue
+++ b/inertia/pages/home/components/main_section.vue
@@ -33,7 +33,7 @@ defineOptions({
       <br />
       please feel free to create a PR on the repository to add it !
     </div>
-    <Button class="mt-6" as="a" theme="primary" left-icon="i-fa6-brands-github">
+    <Button href="https://github.com/adonisjs-community/adonis-packages" class="mt-6" as="a" theme="primary" left-icon="i-fa6-brands-github">
       Contribute on GitHub
     </Button>
   </div>


### PR DESCRIPTION
The "Contribute on GitHub" button shown if there are no search results does not work. 

It seems to be missing the href attribute. 