### PR TITLE
Add adonisjs-server-stats package

### DIFF
--- a/content/packages/adonisjs-server-stats.yml
+++ b/content/packages/adonisjs-server-stats.yml
@@ -1,0 +1,11 @@
+name: adonisjs-server-stats
+category: Monitoring
+npm: adonisjs-server-stats
+repo: simulieren/adonisjs-server-stats
+description: Laravel Telescope-inspired dev toolbar and real-time server monitor for AdonisJS v6
+compatibility:
+  adonis: ^6.0.0
+firstReleaseAt: "2026-02-14T00:00:00.000Z"
+type: 3rd-party
+github: https://github.com/simulieren/adonisjs-server-stats
+website: https://www.npmjs.com/package/adonisjs-server-stats

--- a/content/packages/adonisjs-server-stats.yml
+++ b/content/packages/adonisjs-server-stats.yml
@@ -2,10 +2,13 @@ name: adonisjs-server-stats
 category: Monitoring
 npm: adonisjs-server-stats
 repo: simulieren/adonisjs-server-stats
-description: Laravel Telescope-inspired dev toolbar and real-time server monitor for AdonisJS v6
+description: Laravel Telescope-inspired dev toolbar and real-time server monitor for AdonisJS v6 & v7
 compatibility:
-  adonis: ^6.0.0
-firstReleaseAt: "2026-02-14T00:00:00.000Z"
+  adonis: ^6.0.0 || ^7.0.0
 type: 3rd-party
 github: https://github.com/simulieren/adonisjs-server-stats
-website: https://www.npmjs.com/package/adonisjs-server-stats
+website: https://github.com/simulieren/adonisjs-server-stats
+learn_more: ''
+maintainers:
+  - name: simulieren
+    github: simulieren


### PR DESCRIPTION
## Summary

Adds [adonisjs-server-stats](https://github.com/simulieren/adonisjs-server-stats) to the package listing.

<img width="1322" height="1081" alt="hero" src="https://github.com/user-attachments/assets/0fd4fd92-e903-4448-a02c-0d9d5073bd92" />

A Laravel Telescope-inspired dev toolbar and real-time server monitor for AdonisJS v6 & v7 (~5k monthly npm downloads):

- Live stats bar (CPU, memory, HTTP throughput, DB pool, Redis, queues, logs)
- Debug toolbar with SQL query inspection, EXPLAIN plans, event tracing, route listing, log tailing
- Request-log correlation with waterfall timelines
- React & Vue (Inertia) component libraries alongside Edge templates
- Zero-config setup — auto-detects Lucid, Redis, BullMQ
- Pluggable collector architecture
- Prometheus metrics export with the help of https://github.com/Julien-R44/adonisjs-prometheus
- and much more ...

**npm**: [`adonisjs-server-stats`](https://www.npmjs.com/package/adonisjs-server-stats)
**Category**: Monitoring
**Compatibility**: AdonisJS v6 & v7