### PR TITLE
feat: add adonis-intlayer package configuration

### DIFF
--- a/content/packages/intlayer.yml
+++ b/content/packages/intlayer.yml
@@ -1,0 +1,17 @@
+name: adonis-intlayer
+description: Scoped i18n for AdonisJS apps
+repo: aymericzip/intlayer
+npm: 'adonis-intlayer'
+icon: ''
+github: https://github.com/aymericzip/intlayer
+website: https://intlayer.org/doc/environment/adonisjs
+learn_more: 'https://intlayer.org/doc'
+category: DevTools
+type: 3rd-party
+maintainers:
+  - name: Aymeric PINEAU
+    github: aymericzip
+compatibility:
+  adonis: ^5.0.0 || ^6.0.0 || ^7.0.0
+keywords:
+  - i18n


### PR DESCRIPTION
Added intlayer, i18n solution for error handling and email templates.

Interconnected with intlayer frontend i18n, it can be used to mutualize content declaration with adonis application

Doc https://intlayer.org/doc/environment/adonisjs

